### PR TITLE
Add support to allow uchmviewer to be built as a vcpkg port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(USE_STATIC_CHMLIB  "Use static link with chm library"                OFF)
 option(USE_DEPLOY_RUNTIME "Copy runtime dependencies for deployment"        OFF)
 option(USE_GETTEXT        "Use GNU Gettext for translation"                  ON)
 option(USE_MACOS_BUNDLE   "Install as macOS bundle"                          ON)
-option(NEED_BZIP2_ARCHIVE "Need to link BZip2 static library"                OFF)
+option(IS_VCPKG_BUILD     "Running under vcpkg"                             OFF)
 use_in(USE_DBUS           "Use D-Bus integration"                       "Linux")
 use_in(USE_MAC_APP        "Use derived QApplication"                   "Darwin")
 
@@ -102,11 +102,15 @@ if (${USE_KF5})
 endif ()
 
 #
-# NEED_BZIP2_ARCHIVE is set by the vcpkg portfile.cmake file.  If set, we need to pick up the bzip2
-# archive as libzip will have been built as an archive not a .so/.dylib
+# IS_VCPKG_BUILD is set by the vcpkg portfile.cmake file.  If set, we need to pick up the
+# archive files for:
+#    bzip2
+#    zlib
+# as libzip will have been built as an archive not a .so/.dylib
 #
-if (NEED_BZIP2_ARCHIVE)
+if (IS_VCPKG_BUILD)
     find_package(BZip2 REQUIRED)
+    find_package(ZLIB 1.1.2 REQUIRED)
 endif ()
 
 include(cmake/qt-aliases.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(USE_STATIC_CHMLIB  "Use static link with chm library"                OFF)
 option(USE_DEPLOY_RUNTIME "Copy runtime dependencies for deployment"        OFF)
 option(USE_GETTEXT        "Use GNU Gettext for translation"                  ON)
 option(USE_MACOS_BUNDLE   "Install as macOS bundle"                          ON)
+option(NEED_BZIP2_ARCHIVE "Need to link BZip2 static library"                OFF)
 use_in(USE_DBUS           "Use D-Bus integration"                       "Linux")
 use_in(USE_MAC_APP        "Use derived QApplication"                   "Darwin")
 
@@ -101,10 +102,10 @@ if (${USE_KF5})
 endif ()
 
 #
-# If this variable exists the build is running under vcpkg, and we need to pick up the bzip2
+# NEED_BZIP2_ARCHIVE is set by the vcpkg portfile.cmake file.  If set, we need to pick up the bzip2
 # archive as libzip will have been built as an archive not a .so/.dylib
 #
-if (DEFINED VCPKG_TARGET_IS_OSX)
+if (NEED_BZIP2_ARCHIVE)
     find_package(BZip2 REQUIRED)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,14 @@ if (${USE_KF5})
     target_compile_definitions(extra INTERFACE USE_KDE)
 endif ()
 
+#
+# If this variable exists the build is running under vcpkg, and we need to pick up the bzip2
+# archive as libzip will have been built as an archive not a .so/.dylib
+#
+if (DEFINED VCPKG_TARGET_IS_OSX)
+    find_package(BZip2 REQUIRED)
+endif ()
+
 include(cmake/qt-aliases.cmake)
 include(cmake/install-helper.cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,7 +126,7 @@ target_link_libraries(uchmviewer
 # archive as libzip will have been built as an archive not a .so/.dylib
 #
 if (NEED_BZIP2_ARCHIVE)
-    target_link_libraries(uchmviewer PRIVATE BZip2::BZip2)
+    target_link_libraries(uchmviewer BZip2::BZip2)
 endif ()    
 
 target_link_libraries(uchmviewer i18n)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,6 +121,14 @@ target_link_libraries(uchmviewer
     Qt::Xml
     )
 
+#
+# If the variable VCPKG_TARGET_IS_OSX exists the build is running under vcpkg, and we need to pick up the bzip2
+# archive as libzip will have been built as an archive not a .so/.dylib
+#
+if (DEFINED VCPKG_TARGET_IS_OSX)
+    target_link_libraries(uchmviewer PRIVATE BZip2::BZip2)
+endif ()    
+
 target_link_libraries(uchmviewer i18n)
 # For Gettext to work correctly, we tell the application the location
 # of the folders with binaries and translations.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,10 +122,10 @@ target_link_libraries(uchmviewer
     )
 
 #
-# If the variable VCPKG_TARGET_IS_OSX exists the build is running under vcpkg, and we need to pick up the bzip2
+# NEED_BZIP2_ARCHIVE is set by the vcpkg portfile.cmake file.  If set, we need to pick up the bzip2
 # archive as libzip will have been built as an archive not a .so/.dylib
 #
-if (DEFINED VCPKG_TARGET_IS_OSX)
+if (NEED_BZIP2_ARCHIVE)
     target_link_libraries(uchmviewer PRIVATE BZip2::BZip2)
 endif ()    
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,11 +122,17 @@ target_link_libraries(uchmviewer
     )
 
 #
-# NEED_BZIP2_ARCHIVE is set by the vcpkg portfile.cmake file.  If set, we need to pick up the bzip2
-# archive as libzip will have been built as an archive not a .so/.dylib
+# IS_VCPKG_BUILD is set by the vcpkg portfile.cmake file.  If set, we need to pick up the
+# archive files for:
+#    bzip2
+#    zlib
+# as libzip will have been built as an archive not a .so/.dylib
 #
-if (NEED_BZIP2_ARCHIVE)
-    target_link_libraries(uchmviewer BZip2::BZip2)
+if (IS_VCPKG_BUILD)
+    target_link_libraries(uchmviewer 
+        BZip2::BZip2
+        ZLIB::ZLIB
+        )
 endif ()    
 
 target_link_libraries(uchmviewer i18n)


### PR DESCRIPTION
vcpkg ports are typically archive files rather than .so/.dylibs, so when building under vcpkg there were unresolved externs for stuff from ZLIB and BZip2.

I've added logic such that specifying -DIS_VCPKG_BUILD=ON will add find_package calls for BZip2 and ZLIB,
and to add target_link_libraries for them as well.