### PR TITLE
Fix start minimized

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,7 +152,6 @@ int main( int argc, char** argv )
 		return 0;
 	}
 
-	mainWindow->show();
 	mainWindow->launch();
 
 	app.connect( &app, SIGNAL( lastWindowClosed() ), &app, SLOT( quit() ) );

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -667,6 +667,23 @@ bool MainWindow::parseCmdLineArgs( const QStringList& args, bool from_another_ap
 		}
 	}
 
+	if ( force_background )
+		showMinimized();
+	else
+		show();
+
+	if ( from_another_app )
+	{
+		// On Windows it is not possible to activate the window of a non-active process. From MSDN:
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633539%28v=vs.85%29.aspx
+		//
+		// An application cannot force a window to the foreground while the user is working with another window.
+		// Instead, Windows flashes the taskbar button of the window to notify the user.
+		activateWindow();
+		raise();
+		show();
+	}
+
 	// Opening the file?
 	if ( !filename.isEmpty() )
 	{
@@ -710,20 +727,6 @@ bool MainWindow::parseCmdLineArgs( const QStringList& args, bool from_another_ap
 			m_autoteststate = STATE_INITIAL;
 			showMinimized();
 			runAutoTest();
-		}
-
-		if ( force_background )
-			showMinimized();
-		else if ( from_another_app )
-		{
-			// On Windows it is not possible to activate the window of a non-active process. From MSDN:
-			// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633539%28v=vs.85%29.aspx
-			//
-			// An application cannot force a window to the foreground while the user is working with another window.
-			// Instead, Windows flashes the taskbar button of the window to notify the user.
-			activateWindow();
-			raise();
-			show();
 		}
 
 		return true;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -197,7 +197,7 @@ bool MainWindow::hasSameTokenInstance()
 	QString token;
 
 	// argv[0] in Qt is still a program name
-	for ( int i = 1; i < m_arguments.size(); i++ )
+	for ( int i = 1; i < m_arguments.size() - 1; i++ )
 	{
 		// This is not bulletproof (think -showPage -token) but this is not likely to happen
 		if ( m_arguments[i] == "-token" )
@@ -667,12 +667,7 @@ bool MainWindow::parseCmdLineArgs( const QStringList& args, bool from_another_ap
 		}
 	}
 
-	if ( force_background )
-		showMinimized();
-	else
-		show();
-
-	if ( from_another_app )
+	if ( from_another_app && !force_background && !do_autotest )
 	{
 		// On Windows it is not possible to activate the window of a non-active process. From MSDN:
 		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms633539%28v=vs.85%29.aspx
@@ -681,8 +676,14 @@ bool MainWindow::parseCmdLineArgs( const QStringList& args, bool from_another_ap
 		// Instead, Windows flashes the taskbar button of the window to notify the user.
 		activateWindow();
 		raise();
-		show();
 	}
+
+	if ( force_background || do_autotest )
+		showMinimized();
+	else if ( isMinimized() )
+		showNormal();
+	else
+		show();
 
 	// Opening the file?
 	if ( !filename.isEmpty() )
@@ -721,11 +722,7 @@ bool MainWindow::parseCmdLineArgs( const QStringList& args, bool from_another_ap
 
 		if ( do_autotest )
 		{
-			if ( filename.isEmpty() )
-				qFatal( "Could not use Auto Test mode without a chm file!" );
-
 			m_autoteststate = STATE_INITIAL;
-			showMinimized();
 			runAutoTest();
 		}
 


### PR DESCRIPTION
Fixes #55.
`-background` now works with and without filename.
`-token` now works as it is supposed to be. Actually a default one can be provided.
