### PR TITLE
Fix one index with multiple topic urls

### DIFF
--- a/lib/libebook/ebook_chm.cpp
+++ b/lib/libebook/ebook_chm.cpp
@@ -92,12 +92,12 @@ void EBook_CHM::close()
 
 QString EBook_CHM::title() const
 {
-	return encodeWithCurrentCodec( m_title );
+	return encodeInternalWithCurrentCodec( m_title );
 }
 
 QUrl EBook_CHM::homeUrl() const
 {
-	return pathToUrl( encodeWithCurrentCodec( m_home ) );
+	return pathToUrl( encodeInternalWithCurrentCodec( m_home ) );
 }
 
 bool EBook_CHM::hasFeature( EBook::Feature code ) const
@@ -125,7 +125,7 @@ bool EBook_CHM::getTableOfContents( QList<EBookTocEntry>& toc ) const
 	// Parse the plain text TOC
 	QList< ParsedEntry > parsed;
 
-	if ( !parseFileAndFillArray( encodeWithCurrentCodec( m_topicsFile ), parsed, false ) )
+	if ( !parseFileAndFillArray( encodeInternalWithCurrentCodec( m_topicsFile ), parsed, false ) )
 		return false;
 
 	// Find out the root offset, and reduce the indent level to it
@@ -159,7 +159,7 @@ bool EBook_CHM::getIndex( QList<EBookIndexEntry>& index ) const
 	// Parse the plain text index
 	QList< ParsedEntry > parsed;
 
-	if ( !parseFileAndFillArray( encodeWithCurrentCodec( m_indexFile ), parsed, true ) )
+	if ( !parseFileAndFillArray( encodeInternalWithCurrentCodec( m_indexFile ), parsed, true ) )
 		return false;
 
 	// Find out the root offset, and reduce the indent level to it
@@ -950,11 +950,11 @@ void EBook_CHM::fillTopicsUrlMap()
 		QUrl url = pathToUrl( encodeInternalWithCurrentCodec( ( const char* ) urlstr.data() + off_url ) );
 
 		/*
-		 * Titles are extracted from the <title> field from html pages when compling the chm file, try with text codec.
+		 * Titles are extracted from the <title> field from html pages when compling the chm file.
 		 * These values are used in index search and index with multiple topics selection currently.
 		 */
 		if ( off_title < ( unsigned int )strings.size() )
-			m_url2topics[url] = encodeWithCurrentCodec( ( const char* ) strings.data() + off_title );
+			m_url2topics[url] = encodeInternalWithCurrentCodec( ( const char* ) strings.data() + off_title );
 		else
 			m_url2topics[url] = "Untitled";
 	}

--- a/lib/libebook/ebook_chm.h
+++ b/lib/libebook/ebook_chm.h
@@ -201,7 +201,19 @@ class EBook_CHM : public EBook
 		class ParsedEntry
 		{
 			public:
-				ParsedEntry();
+				ParsedEntry()
+				{
+					iconid = EBookTocEntry::IMAGE_AUTO;
+					indent = 0;
+				}
+				void clear()
+				{
+					name.clear();
+					urls.clear();
+					iconid = EBookTocEntry::IMAGE_AUTO;
+					indent = 0;
+					seealso.clear();
+				}
 
 				QString     name;
 				QList<QUrl> urls;

--- a/lib/libebook/ebook_chm.h
+++ b/lib/libebook/ebook_chm.h
@@ -206,6 +206,7 @@ class EBook_CHM : public EBook
 					iconid = EBookTocEntry::IMAGE_AUTO;
 					indent = 0;
 				}
+
 				void clear()
 				{
 					name.clear();
@@ -245,9 +246,9 @@ class EBook_CHM : public EBook
 
 		//! Encode the string from internal files with the currently selected text codec, if possible.
 		//! Or return as-is, if not.
-		inline QString encodeInternalWithCurrentCodec( const QString& str ) const
+		inline QString encodeInternalWithCurrentCodec( const QByteArray& str ) const
 		{
-			return ( m_textCodecForSpecialFiles ? m_textCodecForSpecialFiles->toUnicode( qPrintable( str ) ) : str );
+			return ( m_textCodecForSpecialFiles ? m_textCodecForSpecialFiles->toUnicode( str.constData() ) : str );
 		}
 
 		//! Encode the string from internal files with the currently selected text codec, if possible.

--- a/src/dialog_topicselector.ui
+++ b/src/dialog_topicselector.ui
@@ -1,30 +1,31 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>DialogTopicSelector</class>
- <widget class="QDialog" name="DialogTopicSelector" >
-  <property name="geometry" >
+ <widget class="QDialog" name="DialogTopicSelector">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>218</width>
+    <width>360</width>
     <height>258</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Multiple topics</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="margin" >
+  <layout class="QVBoxLayout">
+   <property name="margin">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="spacing">
     <number>6</number>
    </property>
    <item>
-    <widget class="QLabel" name="label" >
-     <property name="text" >
+    <widget class="QLabel" name="label">
+     <property name="text">
       <string>Please select the topic to open:</string>
      </property>
-     <property name="alignment" >
+     <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
@@ -33,11 +34,11 @@
     <widget class="QListWidget" name="list" />
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
+     <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
      </property>
     </widget>
@@ -53,11 +54,11 @@
    <receiver>DialogTopicSelector</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>66</x>
      <y>330</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>-3</x>
      <y>275</y>
     </hint>
@@ -69,11 +70,11 @@
    <receiver>DialogTopicSelector</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>151</x>
      <y>327</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>277</x>
      <y>293</y>
     </hint>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -543,6 +543,8 @@ void MainWindow::setTextEncoding( const QString& encoding )
 		}
 	}
 
+	m_navPanel->refresh();
+
 	// Because updateView() will call view->invalidate(), which clears the view->url(),
 	// we have to make a copy of it.
 	QUrl url = currentBrowser()->url();

--- a/src/navigationpanel.cpp
+++ b/src/navigationpanel.cpp
@@ -116,6 +116,8 @@ void NavigationPanel::getSettings( Settings* settings )
 
 void NavigationPanel::refresh()
 {
+	if ( m_indexTab )
+		m_indexTab->refillIndex();
 	if ( m_contentsTab )
 		m_contentsTab->refillTableOfContents();
 }

--- a/src/tab_index.cpp
+++ b/src/tab_index.cpp
@@ -91,7 +91,7 @@ void TabIndex::onTextChanged( const QString& newvalue )
 	{
 		m_lastSelectedItem = items[0];
 		tree->setCurrentItem( m_lastSelectedItem );
-		tree->scrollToItem( m_lastSelectedItem );
+		tree->scrollToItem( m_lastSelectedItem, QAbstractItemView::PositionAtTop );
 	}
 	else
 		m_lastSelectedItem = 0;

--- a/src/tab_index.h
+++ b/src/tab_index.h
@@ -37,6 +37,7 @@ class TabIndex : public QWidget, public Ui::TabIndex
 	public:
 		TabIndex( QWidget* parent = 0 );
 
+		void    refillIndex();
 		void    invalidate();
 		void    search( const QString& index );
 		void    focus();
@@ -49,8 +50,6 @@ class TabIndex : public QWidget, public Ui::TabIndex
 
 	private:
 		void    showEvent( QShowEvent* );
-
-		void    refillIndex();
 
 		QMenu*              m_contextMenu;
 		QTreeWidgetItem*        m_lastSelectedItem;


### PR DESCRIPTION
Use attachment for testing.

Some chm files have one index name links to multiple topics. Just align behavior with `hh.exe`. 

Urls with CJK characters work fine.
In addition, index are now sorted, and the index tree widget scrolls to the matching item to top when searching.

[testindex.zip](https://github.com/user-attachments/files/24753085/testindex.zip)
