### PR TITLE
Add support for navigation following content.opf in epub files

### DIFF
--- a/lib/libebook/ebook.h
+++ b/lib/libebook/ebook.h
@@ -42,8 +42,8 @@ class EBookTocEntry
 		//! Entry name
 		QString     name;
 
-		//! Entry URL.
-		QUrl        url;
+		//! Entry URL. Epub files could associate multiple URLs
+		QList<QUrl> urls;
 
 		//! Associated image number. Used for TOC only; indexes does not have the image.
 		//! If IMAGE_NONE, no icon is associated. Otherwise use getBookIconPixmap() to get associated pixmap icon.

--- a/lib/libebook/ebook_chm.cpp
+++ b/lib/libebook/ebook_chm.cpp
@@ -146,7 +146,7 @@ bool EBook_CHM::getTableOfContents( QList<EBookTocEntry>& toc ) const
 		entry.name = e.name;
 
 		if ( !e.urls.empty() )
-			entry.url = e.urls[0];
+			entry.urls = e.urls;
 
 		toc.append( entry );
 	}
@@ -1068,7 +1068,7 @@ bool EBook_CHM::RecurseLoadBTOC( const QByteArray& tocidx,
 			if ( !entry.name.isEmpty() )
 			{
 				if ( !value.isEmpty() )
-					entry.url = pathToUrl( value );
+					entry.urls.append( pathToUrl( value ) );
 
 				entry.iconid = EBookTocEntry::IMAGE_AUTO;
 				entry.indent = level;

--- a/lib/libebook/ebook_epub.h
+++ b/lib/libebook/ebook_epub.h
@@ -201,8 +201,8 @@ class EBook_EPUB : public EBook
 		// Table of contents
 		QList< EBookTocEntry >  m_tocEntries;
 
-		// Map of URL-Title
-		QMap< QUrl, QString>    m_urlTitleMap;
+		// Map of URL - TOC index
+		QMap< QUrl, int >   m_urlEntryMap;
 };
 
 #endif // EBOOK_EPUB_H

--- a/lib/libebook/helperxmlhandler_epubcontent.h
+++ b/lib/libebook/helperxmlhandler_epubcontent.h
@@ -38,7 +38,7 @@ class HelperXmlHandler_EpubContent : public QXmlDefaultHandler
 		// Manifest storage, id -> href
 		QMap< QString, QString >    manifest;
 
-		// Spline storage
+		// Spine storage, id
 		QList< QString >            spine;
 
 		// TOC (NCX) filename

--- a/lib/libebook/helperxmlhandler_epubtoc.cpp
+++ b/lib/libebook/helperxmlhandler_epubtoc.cpp
@@ -103,7 +103,8 @@ void HelperXmlHandler_EpubTOC::checkNewTocEntry()
 	{
 		EBookTocEntry entry;
 		entry.name = m_lastTitle;
-		entry.url = m_epub->pathToUrl( m_lastId );
+		QUrl url = m_epub->pathToUrl( m_lastId );
+		entry.urls.append( url );
 		entry.iconid = EBookTocEntry::IMAGE_AUTO;
 		entry.indent = m_indent - 1;
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -526,10 +526,10 @@
     <string>Previous</string>
    </property>
    <property name="toolTip">
-    <string>Go to the previous page in the Table of Contents</string>
+    <string>Go to the previous page in the chm or epub file</string>
    </property>
    <property name="whatsThis">
-    <string>Go to the previous page in the &lt;b&gt;Table of Contents&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;i&gt;Shortcut: Ctrl+Left Arrow&lt;/i&gt;</string>
+    <string>Go to the previous page in the chm or epub file&lt;br&gt;&lt;br&gt;&lt;i&gt;Shortcut: Ctrl+Left Arrow&lt;/i&gt;</string>
    </property>
   </action>
   <action name="nav_actionNextPageToc">
@@ -541,10 +541,10 @@
     <string>Next</string>
    </property>
    <property name="toolTip">
-    <string>Go to the next page in the Table of Contents</string>
+    <string>Go to the next page in the chm or epub file</string>
    </property>
    <property name="whatsThis">
-    <string>Go to the next page in the &lt;b&gt;Table of Contents&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;i&gt;Shortcut: Ctrl+Right Arrow&lt;/i&gt;</string>
+    <string>Go to the next page in the chm or epub file&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;i&gt;Shortcut: Ctrl+Right Arrow&lt;/i&gt;</string>
    </property>
   </action>
   <action name="action_Close_window">

--- a/src/navigationpanel.cpp
+++ b/src/navigationpanel.cpp
@@ -154,16 +154,22 @@ void NavigationPanel::showPrevInToc()
 		return;
 
 	// Try to find current list item
-	TreeItem_TOC* current = m_contentsTab->getTreeItem( ::mainWindow->currentBrowser()->url() );
+	QUrl url = ::mainWindow->currentBrowser()->url();
+	TreeItem_TOC* current = m_contentsTab->getTreeItem( url );
 
 	if ( !current )
 		return;
 
-	QTreeWidgetItemIterator lit( current );
-	lit--;
-
-	if ( *lit )
-		::mainWindow->openPage( ( ( TreeItem_TOC* )( *lit ) )->getUrl() );
+	QUrl prevUrl = current->findPrevUrl( url );
+	if ( prevUrl.isEmpty() )
+	{
+		QTreeWidgetItemIterator lit( current );
+		lit--;
+		if ( *lit )
+			::mainWindow->openPage( ( ( TreeItem_TOC* )( *lit ) )->getUrl( false ) );
+	}
+	else
+		::mainWindow->openPage( prevUrl );
 }
 
 void NavigationPanel::showNextInToc()
@@ -172,16 +178,22 @@ void NavigationPanel::showNextInToc()
 		return;
 
 	// Try to find current list item
+	QUrl url = ::mainWindow->currentBrowser()->url();
 	TreeItem_TOC* current = m_contentsTab->getTreeItem( ::mainWindow->currentBrowser()->url() );
 
 	if ( !current )
 		return;
 
-	QTreeWidgetItemIterator lit( current );
-	lit++;
-
-	if ( *lit )
-		::mainWindow->openPage( ( ( TreeItem_TOC* )( *lit ) )->getUrl() );
+	QUrl nextUrl = current->findNextUrl( url );
+	if ( nextUrl.isEmpty() )
+	{
+		QTreeWidgetItemIterator lit( current );
+		lit++;
+		if ( *lit )
+			::mainWindow->openPage( ( ( TreeItem_TOC* )( *lit ) )->getUrl( true ) );
+	}
+	else
+		::mainWindow->openPage( nextUrl );
 }
 
 int NavigationPanel::active() const

--- a/src/tab_contents.cpp
+++ b/src/tab_contents.cpp
@@ -133,7 +133,7 @@ void TabContents::refillTableOfContents( )
 		TreeItem_TOC* item;
 
 		if ( indent == 0 )
-			item = new TreeItem_TOC( tree, lastchild[indent], data[i].name, data[i].url, data[i].iconid );
+			item = new TreeItem_TOC( tree, lastchild[indent], data[i].name, data[i].urls, data[i].iconid );
 		else
 		{
 			// New non-root entry. It is possible (for some buggy CHMs) that there is no previous entry: previous entry had indent 1,
@@ -141,7 +141,7 @@ void TabContents::refillTableOfContents( )
 			if ( rootentry[indent - 1] == 0 )
 				qFatal( "Child entry indented as %d with no root entry!", indent );
 
-			item = new TreeItem_TOC( rootentry[indent - 1], lastchild[indent], data[i].name, data[i].url, data[i].iconid );
+			item = new TreeItem_TOC( rootentry[indent - 1], lastchild[indent], data[i].name, data[i].urls, data[i].iconid );
 		}
 
 		if ( pConfig->m_tocOpenAllEntries )
@@ -156,7 +156,7 @@ void TabContents::refillTableOfContents( )
 
 static TreeItem_TOC* findTreeItem( TreeItem_TOC* item, const QUrl& url, bool ignorefragment )
 {
-	if ( item->containstUrl( url, ignorefragment ) )
+	if ( item->containsUrl( url, ignorefragment ) )
 		return item;
 
 	for ( int i = 0; i < item->childCount(); ++i )

--- a/src/treeitem_index.cpp
+++ b/src/treeitem_index.cpp
@@ -77,7 +77,7 @@ QUrl TreeItem_Index::getUrl() const
 	return dlg.getSelectedItemUrl( m_urls, titles );
 }
 
-bool TreeItem_Index::containstUrl( const QUrl& url ) const
+bool TreeItem_Index::containsUrl( const QUrl& url ) const
 {
 	for ( int i = 0; i < m_urls.size(); i++ )
 	{

--- a/src/treeitem_index.h
+++ b/src/treeitem_index.h
@@ -34,7 +34,7 @@ class TreeItem_Index : public QTreeWidgetItem
 		TreeItem_Index( QTreeWidget* parent, QTreeWidgetItem* after, const QString& name, const QList<QUrl>& urls, const QString& seealso );
 
 		QUrl        getUrl() const;
-		bool        containstUrl( const QUrl& url ) const;
+		bool        containsUrl( const QUrl& url ) const;
 		bool        isSeeAlso() const;
 		QString     seeAlso() const;
 

--- a/src/treeitem_toc.h
+++ b/src/treeitem_toc.h
@@ -29,11 +29,13 @@ class QVariant;
 class TreeItem_TOC : public QTreeWidgetItem
 {
 	public:
-		TreeItem_TOC( QTreeWidgetItem* parent, QTreeWidgetItem* after, const QString& name, const QUrl& url, int image );
-		TreeItem_TOC( QTreeWidget* parent, QTreeWidgetItem* after, const QString& name, const QUrl& url, int image );
+		TreeItem_TOC( QTreeWidgetItem* parent, QTreeWidgetItem* after, const QString& name, const QList<QUrl>& urls, int image );
+		TreeItem_TOC( QTreeWidget* parent, QTreeWidgetItem* after, const QString& name, const QList<QUrl>& urls, int image );
 
-		QUrl        getUrl() const;
-		bool        containstUrl( const QUrl& url, bool ignorefragment ) const;
+		QUrl        getUrl( bool isFirst = true ) const;
+		bool        containsUrl( const QUrl& url, bool ignorefragment ) const;
+		QUrl        findPrevUrl( const QUrl& url );
+		QUrl        findNextUrl( const QUrl& url );
 
 		// Overridden methods
 		int         columnCount() const;
@@ -41,7 +43,7 @@ class TreeItem_TOC : public QTreeWidgetItem
 
 	private:
 		QString     m_name;
-		QUrl        m_url;
+		QList<QUrl> m_urls;
 		int         m_image;
 };
 


### PR DESCRIPTION
Fixes #37. 

Use attachment for testing. There are 3 TOC and 10 pages in the file. Use previous/next button in toolbar to view 'hidden' pages. The file in #37 also works.

To make things easy, 'hidden' pages are associated with a last known TOC entry. When click previous/next button, first check 'hidden' pages before/after the current one, then pages in TOC before/after it.

Two pass to construct the TOC data structure for epub files: In first pass, construct TOC using `toc.ncx`. In second pass, associate pages in `content.opf` but not in `toc.ncx` to TOC data structure.

BTW, it's really hard to be 100% compliant with astyle convention. The whole file got re-formatted after running the tool, which involves incorrect/unintended changes.

[testepub.zip](https://github.com/user-attachments/files/24809845/testepub.zip)
